### PR TITLE
Add PkdGrav3 lightcone reader

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -31,7 +31,7 @@ HDF5_INCLUDE = -I/path/to/hdf5/include
 HDF5_LIB = -L/path/to/hdf5/lib
 HDF5_FLAGS = -DH5_USE_16_API -DENABLE_HDF5 $(HDF5_INCLUDE)
 
-MPI_ROCKSTAR = rockstar.o check_syscalls.o fof.o groupies.o subhalo_metric.o potential.o nfw.o jacobi.o fun_times.o universe_time.o hubble.o integrate.o distance.o config_vars.o config.o bounds.o inthash.o io/read_config.o merger.o io/meta_io.o io/io_internal.o io/io_internal_hdf5.o io/io_ascii.o io/stringparse.o io/io_gadget.o io/io_generic.o io/io_art.o io/io_tipsy.o io/io_bgc2.o io/io_util.o io/io_arepo.o io/io_gadget4.o io/io_hdf5.o io/io_kyf.o interleaving.o mpi_main.o
+MPI_ROCKSTAR = rockstar.o check_syscalls.o fof.o groupies.o subhalo_metric.o potential.o nfw.o jacobi.o fun_times.o universe_time.o hubble.o integrate.o distance.o config_vars.o config.o bounds.o inthash.o io/read_config.o merger.o io/meta_io.o io/io_internal.o io/io_internal_hdf5.o io/io_ascii.o io/stringparse.o io/io_gadget.o io/io_generic.o io/io_art.o io/io_tipsy.o io/io_bgc2.o io/io_util.o io/io_pkdgrav3lcp.o io/io_arepo.o io/io_gadget4.o io/io_hdf5.o io/io_kyf.o interleaving.o mpi_main.o
 
 MPI_ROCKSTAR_HDF5 = $(MPI_ROCKSTAR) io/io_internal_hdf5.o
 

--- a/src/io/io_pkdgrav3lcp.c
+++ b/src/io/io_pkdgrav3lcp.c
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <math.h>
+#include "io_pkdgrav3lcp.h"
+#include "../check_syscalls.h"
+#include "../config_vars.h"
+#include "../universal_constants.h"
+
+#define PKDGRAV3LCP_PARTICLE_BYTES 40
+#define PKDGRAV3LCP_POS_SHIFT 10000.0f
+
+void load_particles_pkdgrav3lcp(char *filename, struct particle **p, int64_t *num_p) {
+    FILE   *input;
+    int64_t file_particles, i, j;
+    int64_t id;
+    float   pos[3], vel[3];
+    char    trash[8];
+    double  vel_unit;
+
+    input = check_fopen(filename, "rb");
+    fseek(input, 0, SEEK_END);
+    file_particles = ftell(input) / PKDGRAV3LCP_PARTICLE_BYTES;
+    if (file_particles <= 0) {
+        fclose(input);
+        return;
+    }
+    fseek(input, 0, SEEK_SET);
+
+    *p = check_realloc(*p, ((*num_p) + file_particles) * sizeof(struct particle),
+                       "Adding pkdgrav3lcp particles.");
+
+    vel_unit = (300.0 * ROCKSTAR_BOX_SIZE) / sqrt(8.0 * M_PI);
+
+    for (i = 0; i < file_particles; i++) {
+        check_fread(&id, sizeof(int64_t), 1, input);
+        check_fread(pos, sizeof(float), 3, input);
+        check_fread(vel, sizeof(float), 3, input);
+        check_fread(trash, 1, 8, input); /* potential + padding */
+
+        (*p)[(*num_p) + i].id = id;
+        for (j = 0; j < 3; j++) {
+            (*p)[(*num_p) + i].pos[j] = pos[j] * ROCKSTAR_BOX_SIZE + PKDGRAV3LCP_POS_SHIFT;
+            (*p)[(*num_p) + i].pos[j + 3] = vel[j] * vel_unit;
+        }
+    }
+
+    *num_p += file_particles;
+    fclose(input);
+
+    if (!ROCKSTAR_PARTICLE_MASS || ROCKSTAR_RESCALE_PARTICLE_MASS) {
+        ROCKSTAR_PARTICLE_MASS = pow(ROCKSTAR_BOX_SIZE, 3) * 2.77536627208e11;
+    }
+    ROCKSTAR_AVG_PARTICLE_SPACING =
+        cbrt(ROCKSTAR_PARTICLE_MASS / (ROCKSTAR_Om * CRITICAL_DENSITY));
+    ROCKSTAR_SCALE_NOW = 1.0;
+}
+

--- a/src/io/io_pkdgrav3lcp.h
+++ b/src/io/io_pkdgrav3lcp.h
@@ -1,0 +1,8 @@
+#ifndef _IO_PKDGRAV3LCP_H_
+#define _IO_PKDGRAV3LCP_H_
+#include <stdint.h>
+#include "../particle.h"
+
+void load_particles_pkdgrav3lcp(char *filename, struct particle **p, int64_t *num_p);
+
+#endif /* _IO_PKDGRAV3LCP_H_ */

--- a/src/io/meta_io.c
+++ b/src/io/meta_io.c
@@ -21,6 +21,7 @@
 #include "io_internal.h"
 #include "io_tipsy.h"
 #include "io_kyf.h" // Added by TI 20160909
+#include "io_pkdgrav3lcp.h"
 #include "meta_io.h"
 #include "../distance.h"
 #include "../version.h"
@@ -90,6 +91,9 @@ void get_input_filename(char *buffer, int maxlen, int64_t snap, int64_t block) {
                         !strncasecmp(ROCKSTAR_FILE_FORMAT, "AREPO", 5) ||
                         !strncasecmp(ROCKSTAR_FILE_FORMAT, "GADGET4", 7))
                         snprintf(buffer + out, maxlen - out, "%03" PRId64,
+                                 snap);
+                    else if (!strncasecmp(ROCKSTAR_FILE_FORMAT, "PKDGRAV3LCP", 11))
+                        snprintf(buffer + out, maxlen - out, "%05" PRId64,
                                  snap);
                     else
                         snprintf(buffer + out, maxlen - out, "%" PRId64, snap);
@@ -171,6 +175,8 @@ void read_particles(char *filename) {
         load_particles_tipsy(filename, &p, &num_p);
     } else if (!strncasecmp(ROCKSTAR_FILE_FORMAT, "KYF", 3)) { // Added by TI 20160909
         load_particles_kyf(filename, &p, &num_p);
+    } else if (!strncasecmp(ROCKSTAR_FILE_FORMAT, "PKDGRAV3LCP", 11)) {
+        load_particles_pkdgrav3lcp(filename, &p, &num_p);
     } else if (!strncasecmp(ROCKSTAR_FILE_FORMAT, "AREPO", 5)) {
 #ifdef ENABLE_HDF5
         load_particles_arepo(filename, &p, &num_p);


### PR DESCRIPTION
## Summary
- add module to load PkdGrav3 lightcone particle data and convert to Rockstar units
- register `pkdgrav3lcp` file format with input filename padding and dispatch
- build support for new reader

## Testing
- `make mpi-rockstar` *(fails: mpicc: No such file or directory)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.131 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68b067ef33348324b5d232a419d8203b