### PR TITLE
Enable MPI-Rockstar as callable library

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ In the original Rockstar, `PID` is the parent halo's ID and can be added by `fin
 make find_parents -C src
 ```
 
+### Building as a Library ###
+
+You can build a static library for linking with other MPI applications:
+```
+make libmpi_rockstar -C src
+```
+The host application must initialize MPI and load a configuration before calling `mpi_main`.  An example program is available in `examples/library_example.c`:
+```
+#include <mpi.h>
+#include "config.h"
+#include "mpi_rockstar.h"
+
+int main(int argc, char **argv) {
+    MPI_Init(&argc, &argv);
+    do_config("parallel_256.cfg");
+    mpi_main(0, NULL);
+    MPI_Finalize();
+    return 0;
+}
+```
+
 In some environments, due to a compatibility issue, you may encounter this or something similar error.
 ```
 /usr/include/tirpc/rpc/xdr.h:111:52: error: unknown type name 'u_int'

--- a/examples/library_example.c
+++ b/examples/library_example.c
@@ -1,0 +1,11 @@
+#include <mpi.h>
+#include "config.h"
+#include "mpi_rockstar.h"
+
+int main(int argc, char **argv) {
+    MPI_Init(&argc, &argv);
+    do_config("parallel_256.cfg");
+    mpi_main(0, NULL);
+    MPI_Finalize();
+    return 0;
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -31,9 +31,12 @@ HDF5_INCLUDE = -I/cluster/software/stacks/2024-06/spack/opt/spack/linux-ubuntu22
 HDF5_LIB = -L/cluster/software/stacks/2024-06/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-12.2.0/hdf5-1.14.3-w2l2wo54rrhvn32ib6plegfvaylh2lne/lib
 HDF5_FLAGS = -DH5_USE_16_API -DENABLE_HDF5 $(HDF5_INCLUDE)
 
-MPI_ROCKSTAR = rockstar.o check_syscalls.o fof.o groupies.o subhalo_metric.o potential.o nfw.o jacobi.o fun_times.o universe_time.o hubble.o integrate.o distance.o config_vars.o config.o bounds.o inthash.o io/read_config.o merger.o io/meta_io.o io/io_internal.o io/io_internal_hdf5.o io/io_ascii.o io/stringparse.o io/io_gadget.o io/io_generic.o io/io_art.o io/io_tipsy.o io/io_bgc2.o io/io_util.o io/io_pkdgrav3lcp.o io/io_arepo.o io/io_gadget4.o io/io_hdf5.o io/io_kyf.o interleaving.o mpi_main.o
+MPI_ROCKSTAR_CORE = rockstar.o check_syscalls.o fof.o groupies.o subhalo_metric.o potential.o nfw.o jacobi.o fun_times.o universe_time.o hubble.o integrate.o distance.o config_vars.o config.o bounds.o inthash.o io/read_config.o merger.o io/meta_io.o io/io_internal.o io/io_internal_hdf5.o io/io_ascii.o io/stringparse.o io/io_gadget.o io/io_generic.o io/io_art.o io/io_tipsy.o io/io_bgc2.o io/io_util.o io/io_pkdgrav3lcp.o io/io_arepo.o io/io_gadget4.o io/io_hdf5.o io/io_kyf.o interleaving.o
+MPI_ROCKSTAR      = $(MPI_ROCKSTAR_CORE) mpi_main.o
+MPI_ROCKSTAR_LIB  = $(MPI_ROCKSTAR_CORE) mpi_main_lib.o
 
-MPI_ROCKSTAR_HDF5 = $(MPI_ROCKSTAR) io/io_internal_hdf5.o
+MPI_ROCKSTAR_HDF5     = $(MPI_ROCKSTAR) io/io_internal_hdf5.o
+MPI_ROCKSTAR_LIB_HDF5 = $(MPI_ROCKSTAR_LIB) io/io_internal_hdf5.o
 
 FIND_PARENTS = find_parents.o io/stringparse.o check_syscalls.o
 
@@ -42,8 +45,23 @@ FIND_PARENTS = find_parents.o io/stringparse.o check_syscalls.o
 .cpp.o: 
 	$(CXX) $(CXXFLAGS) $(EXTRA_FLAGS) -c -o $@ $<
 
-.c.o: 
+.c.o:
 	$(CC) $(CFLAGS) $(EXTRA_FLAGS) -c -o $@ $< -I/usr/include/tirpc
+
+mpi_main_lib.o: mpi_main.cpp
+	$(CXX) $(CXXFLAGS) $(EXTRA_FLAGS) -DMPI_ROCKSTAR_LIBRARY -c -o $@ $<
+
+.PHONY: libmpi_rockstar
+libmpi_rockstar: $(MPI_ROCKSTAR_LIB)
+	ar rcs ../libmpi_rockstar.a $^
+
+.PHONY: libmpi_rockstar_hdf5
+libmpi_rockstar_hdf5:
+	make _libmpi_rockstar_hdf5 EXTRA_FLAGS="$(HDF5_FLAGS)"
+
+.PHONY: _libmpi_rockstar_hdf5
+_libmpi_rockstar_hdf5: $(MPI_ROCKSTAR_LIB_HDF5)
+	ar rcs ../libmpi_rockstar_hdf5.a $^ $(HDF5_LIB)
 
 .PHONY: mpi-rockstar
 mpi-rockstar: $(MPI_ROCKSTAR)
@@ -62,4 +80,4 @@ find_parents: $(FIND_PARENTS)
 	$(CC) $(CFLAGS) -o ../$@ $^ -lm
 
 clean:
-	rm -f *.o *~ io/*.o io/*~
+	rm -f *.o *~ io/*.o io/*~ ../libmpi_rockstar.a ../libmpi_rockstar_hdf5.a

--- a/src/mpi_main.cpp
+++ b/src/mpi_main.cpp
@@ -36,6 +36,8 @@ extern "C" {
 #include "version.h"
 }
 
+#include "mpi_rockstar.h"
+
 #define CLIENT_DEBUG 0
 FILE  *profile_out = NULL;
 double time_start;
@@ -1907,7 +1909,7 @@ void check_config( const int my_rank){
 
 
 
-void mpi_main(int argc, char *argv[]) {
+extern "C" void mpi_main(int argc, char *argv[]) {
 
     char    buffer[1024];
     int64_t reload_parts = 0;
@@ -1920,12 +1922,14 @@ void mpi_main(int argc, char *argv[]) {
     MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
     MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
 
+    #ifndef MPI_ROCKSTAR_LIBRARY
     if (my_rank==0 && argc < 2) {
         printf("MPI-Rockstar Halo Finder, Version %s\n", ROCKSTAR_VERSION);
         printf("(C) See the README file for redistribution details.\n");
         printf("Usage: %s [-c config]\n", argv[0]);
         exit(1);
     }
+    #endif
 
     ROCKSTAR_NUM_WRITERS = num_procs;
     ROCKSTAR_NUM_READERS = (ROCKSTAR_NUM_BLOCKS > num_procs) ? num_procs : ROCKSTAR_NUM_BLOCKS;
@@ -2022,7 +2026,7 @@ void mpi_main(int argc, char *argv[]) {
 
 
 
-
+#ifndef MPI_ROCKSTAR_LIBRARY
 int main(int argc, char **argv) {
 
     int64_t i, snap = -1, did_config = 0;
@@ -2055,3 +2059,4 @@ int main(int argc, char **argv) {
     return 0;
 
 }
+#endif /* MPI_ROCKSTAR_LIBRARY */

--- a/src/mpi_rockstar.h
+++ b/src/mpi_rockstar.h
@@ -1,0 +1,14 @@
+#ifndef MPI_ROCKSTAR_H
+#define MPI_ROCKSTAR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void mpi_main(int argc, char *argv[]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MPI_ROCKSTAR_H */


### PR DESCRIPTION
## Summary
- Add `mpi_rockstar.h` and `mpi_main` export to allow library use
- Create `libmpi_rockstar.a` target in Makefile
- Document and provide example for linking Rockstar from external MPI apps

## Testing
- `make libmpi_rockstar -C src` *(fails: mpicc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b19b6e71b08324bfcdb892e513cdd2