### PR TITLE
Refactor example configuration invocation

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,12 @@
+CC=mpicxx
+CFLAGS=-I../src
+LDFLAGS=../libmpi_rockstar.a -lm -ltirpc
+
+example: example.o ../libmpi_rockstar.a
+	$(CC) -o $@ example.o $(LDFLAGS)
+
+example.o: example.c
+	$(CC) $(CFLAGS) -c -o $@ example.c
+
+clean:
+	rm -f example.o example

--- a/examples/example.c
+++ b/examples/example.c
@@ -1,10 +1,14 @@
 #include <mpi.h>
+
+extern "C" {
 #include "config.h"
 #include "mpi_rockstar.h"
+}
 
 int main(int argc, char **argv) {
     MPI_Init(&argc, &argv);
-    do_config("parallel_256.cfg");
+    char cfg[] = "rockstar_lightcone.config";
+    do_config(cfg);
     mpi_main(0, NULL);
     MPI_Finalize();
     return 0;


### PR DESCRIPTION
## Summary
- move example's C headers into an `extern "C"` block for C++ builds
- call `do_config` using a variable string
- add a simple Makefile for building the example

## Testing
- `make -C src libmpi_rockstar` *(fails: mpicc: No such file or directory)*
- `make -C examples` *(fails: mpicxx: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b20426a9488324af2729d985da5a3b