### PR TITLE
Allow example config file via command line

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,12 +1,16 @@
 CC=mpicxx
 CFLAGS=-I../src -fopenmp
 LDFLAGS=../libmpi_rockstar.a -lm -ltirpc -fopenmp
+HDF5_LDFLAGS=../libmpi_rockstar_hdf5.a -lm -ltirpc -fopenmp -lhdf5 -lz
 
 example: example.o ../libmpi_rockstar.a
 	$(CC) -o $@ example.o $(LDFLAGS)
+
+example_hdf5: example.o ../libmpi_rockstar_hdf5.a
+	$(CC) -o $@ example.o $(HDF5_LDFLAGS)
 
 example.o: example.c
 	$(CC) $(CFLAGS) -c -o $@ example.c
 
 clean:
-	rm -f example.o example
+	rm -f example.o example example_hdf5

--- a/examples/example.c
+++ b/examples/example.c
@@ -1,4 +1,5 @@
 #include <mpi.h>
+#include <stdio.h>
 
 extern "C" {
 #include "config.h"
@@ -7,7 +8,14 @@ extern "C" {
 
 int main(int argc, char **argv) {
     MPI_Init(&argc, &argv);
-    char cfg[] = "rockstar_lightcone.config";
+
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <config_file>\n", argv[0]);
+        MPI_Finalize();
+        return 1;
+    }
+
+    char *cfg = argv[1];
     do_config(cfg);
     mpi_main(0, NULL);
     MPI_Finalize();


### PR DESCRIPTION
## Summary
- allow examples/example.c to read config file path from argv[1]
- print a usage message when no configuration file is supplied

## Testing
- `make libmpi_rockstar -C src` *(fails: mpicc not found)*
- `make -C examples` *(fails: mpicxx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b209da16c08324a7f7e0fbb7cd96ee