### PR TITLE
Load configuration before calling mpi_main in demo example

### DIFF
--- a/demo_librockstar/example.c
+++ b/demo_librockstar/example.c
@@ -14,7 +14,8 @@ int main(int argc, char **argv) {
         MPI_Finalize();
         return 1;
     }
-    mpi_main(argc, argv);
+    do_config(argv[1]);
+    mpi_main(0, NULL);
     MPI_Finalize();
     return 0;
 }


### PR DESCRIPTION
## Summary
- Ensure demo_librockstar example loads the config file and then calls `mpi_main` without arguments

## Testing
- `make clean && make example_hdf5` *(fails: mpicxx: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b44cbb9bc4832483bc220ba3346f3a