### PR TITLE
Limit demo exposure to library interface

### DIFF
--- a/demo_librockstar/Makefile
+++ b/demo_librockstar/Makefile
@@ -1,5 +1,5 @@
 CC=mpicxx
-CFLAGS=-I../src -fopenmp
+CFLAGS=-fopenmp
 LDFLAGS=../libmpi_rockstar.a -lm -ltirpc -fopenmp
 HDF5_LDFLAGS=../libmpi_rockstar_hdf5.a -lm -ltirpc -fopenmp -lhdf5 -lz
 

--- a/demo_librockstar/example.c
+++ b/demo_librockstar/example.c
@@ -1,14 +1,10 @@
-#include <mpi.h>
-
-/* Declare only the function needed from the library to avoid exposing
- * internal headers. */
+/* Declare only the single entry point from the library to avoid exposing
+ * internal headers or functions. */
 extern "C" {
-int rockstar_mpi_main(int argc, char **argv);
+void rockstar_mpi_main(int argc, char **argv);
 }
 
 int main(int argc, char **argv) {
-    MPI_Init(&argc, &argv);
     rockstar_mpi_main(argc, argv);
-    MPI_Finalize();
     return 0;
 }

--- a/demo_librockstar/example.c
+++ b/demo_librockstar/example.c
@@ -1,21 +1,14 @@
 #include <mpi.h>
-#include <stdio.h>
 
+/* Declare only the function needed from the library to avoid exposing
+ * internal headers. */
 extern "C" {
-#include "config.h"
-#include "mpi_rockstar.h"
+int rockstar_mpi_main(int argc, char **argv);
 }
 
 int main(int argc, char **argv) {
     MPI_Init(&argc, &argv);
-
-    if (argc < 2) {
-        fprintf(stderr, "Usage: %s <config_file>\n", argv[0]);
-        MPI_Finalize();
-        return 1;
-    }
-    do_config(argv[1]);
-    rockstar_mpi_main(0, NULL);
+    rockstar_mpi_main(argc, argv);
     MPI_Finalize();
     return 0;
 }

--- a/demo_librockstar/example.c
+++ b/demo_librockstar/example.c
@@ -1,10 +1,15 @@
 /* Declare only the single entry point from the library to avoid exposing
- * internal headers or functions. */
+ * internal headers or functions, but initialize MPI locally. */
+
+#include <mpi.h>
+
 extern "C" {
 void rockstar_mpi_main(int argc, char **argv);
 }
 
 int main(int argc, char **argv) {
+    MPI_Init(&argc, &argv);
     rockstar_mpi_main(argc, argv);
+    MPI_Finalize();
     return 0;
 }

--- a/src/io/read_config.c
+++ b/src/io/read_config.c
@@ -151,6 +151,7 @@ inline static void trim(char **a, char **b) {
 }
 
 void load_config(struct configfile *c, char *filename) {
+    
     char  buffer[1024];
     FILE *input;
     char *key_start, *key_end;
@@ -161,8 +162,7 @@ void load_config(struct configfile *c, char *filename) {
     if (!input) {
         c->num_entries = 0;
         return;
-    }
-
+    } 
     int totaln_config = 0;
     char *file_format = NULL;
 
@@ -187,26 +187,30 @@ void load_config(struct configfile *c, char *filename) {
         add_to_string_array(&(c->keys), key_start, key_end - key_start + 1,
                             c->num_entries);
 
-	if( !strncasecmp( c->keys[c->num_entries], "TOTAL_PARTICLES", 15)){
-	  totaln_config = 1;
-	}
+        if( !strncasecmp( c->keys[c->num_entries], "TOTAL_PARTICLES", 15)){
+        totaln_config = 1;
+        }
 
         add_to_string_array(&(c->values), val_start, val_end - val_start + 1,
                             c->num_entries);
         add_to_int_array(&(c->touched), c->num_entries, 0);
 
-	if( !strncasecmp( c->keys[c->num_entries], "FILE_FORMAT", 11)){
-	  file_format = c->values[c->num_entries];
-	}
+        if( !strncasecmp( c->keys[c->num_entries], "FILE_FORMAT", 11)){
+        file_format = c->values[c->num_entries];
+        }
 
         c->num_entries++;
     }
     fclose(input);
-
+    if (file_format == NULL) {
+        fprintf(stderr, "[Error] FILE_FORMAT is not set in the config file %s\n", filename);
+        exit(1);
+    }
     if( !strncasecmp(file_format, "KYF", 3) && !totaln_config){
       fprintf(stderr, "[Error] TOTAL_PARTICLES is not set\n");
       exit(1);
     }
+
 
 }
 

--- a/src/mpi_main.cpp
+++ b/src/mpi_main.cpp
@@ -1968,8 +1968,6 @@ void mpi_main(int argc, char *argv[]){
     MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
     MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
 
-    fprintf(stderr, "mpi_main: my_rank: %d, num_procs: %d\n", my_rank, num_procs);
-
     #ifndef MPI_ROCKSTAR_LIBRARY
     if (my_rank==0 && argc < 2) {
         printf("MPI-Rockstar Halo Finder, Version %s\n", ROCKSTAR_VERSION);
@@ -1978,10 +1976,6 @@ void mpi_main(int argc, char *argv[]){
         exit(1);
     }
     #endif
-
-    fprintf(stderr, "mpi_main: my_rank: %d, PERIODIC: %d\n", my_rank, PERIODIC);
-    fprintf(stderr, "mpi_main: my_rank: %d, LIGHTCONE: %d\n", my_rank, LIGHTCONE);
-    fprintf(stderr, "mpi_main: my_rank: %d, FILENAME: %s\n", my_rank, FILENAME);
 
     NUM_WRITERS = num_procs;
     NUM_READERS = (NUM_BLOCKS > num_procs) ? num_procs : NUM_BLOCKS;


### PR DESCRIPTION
## Summary
- Avoid exposing internal headers in demo by forward declaring `rockstar_mpi_main`
- Drop internal include path from demo Makefile
- Delegate configuration handling to `rockstar_mpi_main`

## Testing
- `make example` *(fails: mpicxx: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b468ce1c40832481de80f55fb507a9