### PR TITLE
Introduce central error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ export OMP_NUM_THREADS=<the number of OpenMP threads>
 ```
 When you use a batch job system, please follow the instruction of the system.
 
+### Error handling
+The original Rockstar code terminated the process directly on failure using `exit(1)`. MPI-Rockstar now routes all such failures
+through a central handler. The default handler throws a `rockstar_error` exception, which the provided `mpi-rockstar` executable
+catches to report the error and finalize MPI cleanly. Applications can override this behaviour with
+```
+rockstar_set_error_handler(my_handler);
+```
+where `my_handler` is a function matching `void handler(int code, const char *file, int line)`. This allows library users to
+clean up resources, convert Rockstar errors into their own error reporting system, or perform their own collective MPI shutdown
+before deciding how to handle the failure.
+
 In the original Rockstar, `PID` is the parent halo's ID and can be added by `find_parents` after running the Rockstar. You can also compile it by
 ```
 make find_parents -C src

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,8 +20,8 @@ CXX = mpiFCCpx
 OFLAGS = -Nclang -Ofast -fopenmp # -I/usr/include/tirpc
 endif
 
-CFLAGS   = -m64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_DEFAULT_SOURCE -D_POSIX_SOURCE -D_POSIX_C_SOURCE=200809L -D_SVID_SOURCE -D_DARWIN_C_SOURCE -Wall -fno-math-errno -fPIC -std=c99 
-CXXFLAGS = -Wall -fno-math-errno -fPIC -std=c++11
+CFLAGS   = -m64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_DEFAULT_SOURCE -D_POSIX_SOURCE -D_POSIX_C_SOURCE=200809L -D_SVID_SOURCE -D_DARWIN_C_SOURCE -Wall -fno-math-errno -fPIC -std=c99 -fexceptions
+CXXFLAGS = -Wall -fno-math-errno -fPIC -std=c++11 -fexceptions
 #ADDFLAGS = -DOUTPUT_RVMAX -DOUTPUT_NFW_CHI2 -DOUTPUT_INTERMEDIATE_AXIS
 ADDFLAGS = -DOUTPUT_RVMAX -DOUTPUT_NFW_CHI2 -DOUTPUT_INERTIA_TENSOR
 CFLAGS   += $(ADDFLAGS) $(OFLAGS) -DDO_CONFIG_MPI -DOMPI_SKIP_MPICXX -DMPICH_SKIP_MPICXX
@@ -31,7 +31,7 @@ HDF5_INCLUDE = -I/cluster/software/stacks/2024-06/spack/opt/spack/linux-ubuntu22
 HDF5_LIB = -L/cluster/software/stacks/2024-06/spack/opt/spack/linux-ubuntu22.04-x86_64_v3/gcc-12.2.0/hdf5-1.14.3-w2l2wo54rrhvn32ib6plegfvaylh2lne/lib
 HDF5_FLAGS = -DH5_USE_16_API -DENABLE_HDF5 $(HDF5_INCLUDE)
 
-MPI_ROCKSTAR_CORE = rockstar.o check_syscalls.o fof.o groupies.o subhalo_metric.o potential.o nfw.o jacobi.o fun_times.o universe_time.o hubble.o integrate.o distance.o config_vars.o config.o bounds.o inthash.o io/read_config.o merger.o io/meta_io.o io/io_internal.o io/io_internal_hdf5.o io/io_ascii.o io/stringparse.o io/io_gadget.o io/io_generic.o io/io_art.o io/io_tipsy.o io/io_bgc2.o io/io_util.o io/io_pkdgrav3lcp.o io/io_arepo.o io/io_gadget4.o io/io_hdf5.o io/io_kyf.o interleaving.o
+MPI_ROCKSTAR_CORE = rockstar.o check_syscalls.o error.o fof.o groupies.o subhalo_metric.o potential.o nfw.o jacobi.o fun_times.o universe_time.o hubble.o integrate.o distance.o config_vars.o config.o bounds.o inthash.o io/read_config.o merger.o io/meta_io.o io/io_internal.o io/io_internal_hdf5.o io/io_ascii.o io/stringparse.o io/io_gadget.o io/io_generic.o io/io_art.o io/io_tipsy.o io/io_bgc2.o io/io_util.o io/io_pkdgrav3lcp.o io/io_arepo.o io/io_gadget4.o io/io_hdf5.o io/io_kyf.o interleaving.o
 MPI_ROCKSTAR      = $(MPI_ROCKSTAR_CORE) mpi_main.o
 MPI_ROCKSTAR_LIB  = $(MPI_ROCKSTAR_CORE) mpi_main_lib.o
 

--- a/src/check_syscalls.h
+++ b/src/check_syscalls.h
@@ -2,6 +2,7 @@
 #define CHECK_SYSCALLS_H
 #include <stdio.h>
 #include <stdlib.h>
+#include "error.h"
 #include <inttypes.h>
 #include <sys/types.h>
 

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,0 +1,22 @@
+#include "error.h"
+
+static rockstar_error_handler current_handler = rockstar_default_error_handler;
+
+void rockstar_set_error_handler(rockstar_error_handler handler)
+{
+    if (handler) {
+        current_handler = handler;
+    } else {
+        current_handler = rockstar_default_error_handler;
+    }
+}
+
+void rockstar_default_error_handler(int code, const char *file, int line)
+{
+    throw rockstar_error(code, file, line);
+}
+
+void rockstar_abort_impl(int code, const char *file, int line)
+{
+    current_handler(code, file, line);
+}

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,34 @@
+#ifndef ROCKSTAR_ERROR_H
+#define ROCKSTAR_ERROR_H
+
+#include <mpi.h>
+
+#ifdef __cplusplus
+#include <exception>
+extern "C" {
+#endif
+
+typedef void (*rockstar_error_handler)(int code, const char *file, int line);
+
+void rockstar_set_error_handler(rockstar_error_handler handler);
+void rockstar_default_error_handler(int code, const char *file, int line);
+void rockstar_abort_impl(int code, const char *file, int line);
+
+#define rockstar_abort(code) rockstar_abort_impl((code), __FILE__, __LINE__)
+
+/* Replace any direct call to exit() inside the code base. */
+#define exit(code) rockstar_abort(code)
+
+#ifdef __cplusplus
+}
+
+struct rockstar_error : public std::exception {
+    int code;
+    const char *file;
+    int line;
+    rockstar_error(int c, const char *f, int l) : code(c), file(f), line(l) {}
+    const char *what() const noexcept override { return "rockstar error"; }
+};
+#endif
+
+#endif /* ROCKSTAR_ERROR_H */

--- a/src/fast3tree.c
+++ b/src/fast3tree.c
@@ -58,6 +58,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include "error.h"
 #include <string.h>
 #include <math.h>
 #include <inttypes.h>

--- a/src/io/io_hdf5.c
+++ b/src/io/io_hdf5.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <hdf5.h> /* HDF5 required */
 #include <inttypes.h>
+#include "../error.h"
 
 hid_t check_H5Fopen(char *filename, unsigned flags) {
     hid_t HDF_FileID = H5Fopen(filename, flags, H5P_DEFAULT);

--- a/src/io/read_config.c
+++ b/src/io/read_config.c
@@ -7,6 +7,7 @@
 #include <inttypes.h>
 #include <ctype.h>
 #include "read_config.h"
+#include "../error.h"
 
 void add_to_string_array(char ***array, char *string, size_t length,
                          int num_entries) {

--- a/src/load_balance.c
+++ b/src/load_balance.c
@@ -1,3 +1,5 @@
+#include "error.h"
+
 void factor_3(int64_t in, int64_t *factors) {
     int64_t i, n = 0;
     for (i = ceil(fabs(cbrt(in))); i > 0 && n < 2; i--)

--- a/src/mpi_main.cpp
+++ b/src/mpi_main.cpp
@@ -11,8 +11,10 @@
 #include <cstdarg>
 #include <cstddef>
 #include <ctime>
+#include <cstdio>
 #include <sys/stat.h>
 
+#include "error.h"
 extern "C" {
 #include "config_vars.h"
 #include "check_syscalls.h"
@@ -2084,9 +2086,16 @@ int main(int argc, char **argv) {
 #ifdef DO_CONFIG_MPI
     init_mpi( argc, argv);
 #endif
-    
-    mpi_main(argc, argv);
 
+    try {
+        mpi_main(argc, argv);
+    } catch (const rockstar_error &err) {
+#ifdef DO_CONFIG_MPI
+        MPI_Finalize();
+#endif
+        fprintf(stderr, "Rockstar error %d at %s:%d\n", err.code, err.file, err.line);
+        return err.code;
+    }
 
 
 #ifdef DO_CONFIG_MPI

--- a/src/rockstar.h
+++ b/src/rockstar.h
@@ -5,6 +5,7 @@
 #include "particle.h"
 #include "halo.h"
 #include "fof.h"
+#include "error.h"
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846264338327950288 /* From math.h */


### PR DESCRIPTION
## Summary
- Replace default MPI abort with an exception-based `rockstar_error` handler
- Catch `rockstar_error` in `mpi_main` to finalize MPI cleanly
- Enable exception support in build flags and document the new workflow

## Testing
- `make mpi-rockstar -C src` *(fails: mpicc: No such file or directory)*
- `apt-get update` *(fails: 403  Forbidden)*
- `apt-get install -y mpich` *(fails: Unable to locate package mpich)*

------
https://chatgpt.com/codex/tasks/task_e_68b48ae0eeec8324a6ffd562deef299e