### PR TITLE
Add lightcone padding to load neighboring snapshots

### DIFF
--- a/src/config.template.h
+++ b/src/config.template.h
@@ -97,6 +97,7 @@ integer(EXACT_LL_CALC, 0);
 real(TRIM_OVERLAP, 0);
 real(ROUND_AFTER_TRIM, 1);
 integer(LIGHTCONE, 0);
+integer(LIGHTCONE_PADDING, 0);
 integer(PERIODIC, 1);
 
 real3(LIGHTCONE_ORIGIN, "0 0 0");


### PR DESCRIPTION
## Summary
- add LIGHTCONE_PADDING config option for lightcone runs
- load neighbor snapshots within padding window and skip missing files
- only load neighboring snapshots when LIGHTCONE is enabled and padding is nonzero

## Testing
- `make -C src` *(fails: mpicc not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8f7aa7348324a90df8f50fa93e2b