### PR TITLE
Implement root-only sample gather with configurable fraction

### DIFF
--- a/src/config.template.h
+++ b/src/config.template.h
@@ -144,5 +144,7 @@ integer(SUBDIR_DIGITS_OUTPUT, 4);    // and the length of subdir names (or sub-s
 // Additional parameters for MPI Rockstar for memory saving transfer
 integer(MEMORY_SAVING_TRANSFER, 0); // Flag for using memory saving transfer
 
-// Fraction of local particles to sample when computing domain bounds
-real(SAMPLE_FRACTION, 0.1);
+// Maximum number of particles sampled across all ranks when computing
+// domain bounds. Sampling fraction is fixed at 0.1 but capped by this
+// limit to reduce memory usage on the root rank.
+integer(NUM_MAX_SAMPLES_DOMAIN_DECOMP, 1000000);

--- a/src/config.template.h
+++ b/src/config.template.h
@@ -143,3 +143,6 @@ integer(SUBDIR_DIGITS_OUTPUT, 4);    // and the length of subdir names (or sub-s
 
 // Additional parameters for MPI Rockstar for memory saving transfer
 integer(MEMORY_SAVING_TRANSFER, 0); // Flag for using memory saving transfer
+
+// Fraction of local particles to sample when computing domain bounds
+real(SAMPLE_FRACTION, 0.1);


### PR DESCRIPTION
## Summary
- Add `SAMPLE_FRACTION` config option for controlling fraction of particles used during domain alignment
- Replace `MPI_Allgather` with root-only gather and broadcast so only root holds full sample
- Refactor `align_domain_particles` to work on streamed/batched samples without an auxiliary index array
- Document each logical block in `align_domain_particles` with explanatory comments

## Testing
- `make -C src mpi-rockstar` *(fails: mpicc: No such file or directory)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8b38e8b88324b89de0c4571248ee